### PR TITLE
Replace TextInputAction.newline handling with enterToInsertBlockNewline

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -1038,10 +1038,13 @@ class SoftwareKeyboardHandler {
   void performAction(TextInputAction action) {
     switch (action) {
       case TextInputAction.newline:
-        if (!composer.selection!.isCollapsed) {
-          commonOps.deleteSelection();
-        }
-        commonOps.insertBlockLevelNewline();
+        // Logic below was commented out to fix https://simpleclub.atlassian.net/browse/SC-9328.
+        // This action is now handled by [enterToInsertBlockNewline]. See it in [defaultImeKeyboardActions].
+        //
+        // if (!composer.selection!.isCollapsed) {
+        //   commonOps.deleteSelection();
+        // }
+        // commonOps.insertBlockLevelNewline();
         break;
       case TextInputAction.none:
         // no-op

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -758,6 +758,7 @@ final defaultImeKeyboardActions = <DocumentKeyboardAction>[
   cmdBToToggleBold,
   cmdIToToggleItalics,
   shiftEnterToInsertNewlineInBlock,
+  enterToInsertBlockNewline,
   backspaceToRemoveUpstreamContent,
   deleteToRemoveDownstreamContent,
 ];


### PR DESCRIPTION
This fixes https://simpleclub.atlassian.net/browse/SC-9328

Now pressing Enter in bulleted and ordered lists is handled properly by creating a new bullet.