### PR TITLE
Correct accessing Scrollable in parent tree

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -141,7 +141,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
       });
 
       // Display the toolbar in the application overlay.
-      final overlay = Overlay.of(context)!;
+      final overlay = Overlay.of(context);
       overlay.insert(_textFormatBarOverlayEntry!);
     }
 
@@ -242,7 +242,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
       });
 
       // Display the toolbar in the application overlay.
-      final overlay = Overlay.of(context)!;
+      final overlay = Overlay.of(context);
       overlay.insert(_imageFormatBarOverlayEntry!);
     }
 

--- a/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
@@ -46,7 +46,7 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
       return;
     }
 
-    final overlay = Overlay.of(context)!;
+    final overlay = Overlay.of(context);
     final overlayBox = overlay.context.findRenderObject() as RenderBox?;
     final textFieldBox = textFieldContext.findRenderObject() as RenderBox;
     _popupOffset = textFieldBox.localToGlobal(localOffset, ancestor: overlayBox);

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -49,7 +49,7 @@ class ScrollableDocument extends StatelessWidget {
   final Widget child;
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -598,7 +598,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
         );
       });
 
-      Overlay.of(context)!.insert(_controlsOverlayEntry!);
+      Overlay.of(context).insert(_controlsOverlayEntry!);
     }
   }
 
@@ -910,7 +910,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -872,7 +872,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       );
     });
 
-    Overlay.of(context)!.insert(_controlsOverlayEntry!);
+    Overlay.of(context).insert(_controlsOverlayEntry!);
   }
 
   void _positionCaret() {
@@ -1073,7 +1073,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -89,8 +89,8 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
     // ancestor ScrollingMinimaps.
     if (widget.scrollingMinimapId != null) {
       _debugInstrumentation = ScrollableInstrumentation()
-        ..viewport.value = Scrollable.of(context)!.context
-        ..scrollPosition.value = Scrollable.of(context)!.position;
+        ..viewport.value = Scrollable.of(context).context
+        ..scrollPosition.value = Scrollable.of(context).position;
       ScrollingMinimaps.of(context)?.put(widget.scrollingMinimapId!, _debugInstrumentation);
     }
   }
@@ -156,7 +156,7 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
   ScrollPosition get _scrollPosition => _ancestorScrollPosition ?? _scrollController.position;
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -350,7 +350,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
         );
       });
 
-      Overlay.of(context)!.insert(_controlsOverlayEntry!);
+      Overlay.of(context).insert(_controlsOverlayEntry!);
     }
   }
 
@@ -447,7 +447,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/fill_width_if_constrained.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/fill_width_if_constrained.dart
@@ -25,7 +25,7 @@ class FillWidthIfConstrained extends SingleChildRenderObjectWidget {
   }
 
   double? _getViewportWidth(BuildContext context) {
-    final scrollable = Scrollable.of(context);
+    final scrollable = Scrollable.maybeOf(context);
     if (scrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -365,7 +365,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         );
       });
 
-      Overlay.of(context)!.insert(_controlsOverlayEntry!);
+      Overlay.of(context).insert(_controlsOverlayEntry!);
     }
   }
 
@@ -443,7 +443,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -513,7 +513,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
         );
       });
 
-      Overlay.of(context)!.insert(_controlsOverlayEntry!);
+      Overlay.of(context).insert(_controlsOverlayEntry!);
     }
   }
 
@@ -741,7 +741,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -760,7 +760,7 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
       );
     });
 
-    Overlay.of(context)!.insert(_controlsOverlayEntry!);
+    Overlay.of(context).insert(_controlsOverlayEntry!);
   }
 
   void _positionExpandedSelectionHandles() {
@@ -885,7 +885,7 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
   }
 
   ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = Scrollable.maybeOf(context);
     if (ancestorScrollable == null) {
       return null;
     }

--- a/super_editor/test/super_editor/supereditor_popover_focus_test.dart
+++ b/super_editor/test/super_editor/supereditor_popover_focus_test.dart
@@ -104,7 +104,7 @@ Future<void> _showPopover(
     );
   });
 
-  Overlay.of(context)!.insert(_overlayEntry!);
+  Overlay.of(context).insert(_overlayEntry!);
 
   await tester.pump();
 }

--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -97,7 +97,7 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
 
       // Display the toolbar in the application overlay.
       final overlay = Overlay.of(context);
-      overlay!.insert(_formatBarOverlayEntry!);
+      overlay.insert(_formatBarOverlayEntry!);
 
       // Schedule a callback after this frame to locate the selection
       // bounds on the screen and display the toolbar near the selected


### PR DESCRIPTION
Flutter 3.7 introduced some behavior changes to `XXX.of(BuildContext)`. This adjusts the code to the new behavior/API.